### PR TITLE
add readTemperature command and examples/get_info.rs

### DIFF
--- a/examples/get_info.rs
+++ b/examples/get_info.rs
@@ -1,0 +1,22 @@
+use std::io::{self};
+
+use feetech_servo_rs::{Command, Driver};
+
+fn main() {
+    println!("Enter the port (default: /dev/ttyACM0):");
+    let mut port = String::new();
+    let _ = io::stdin().read_line(&mut port);
+    let port = match port.trim() {
+        "" => "/dev/ttyACM0",
+        other => other,
+    };
+    let mut driver = Driver::new(port);
+
+    println!("Enter the number of motors:");
+    let mut num_motors = String::new();
+    let _ = io::stdin().read_line(&mut num_motors);
+    let num_motors: u8 = num_motors.trim().parse().expect("Please type a number!");
+    for motor_id in 1..=num_motors {
+        println!("motor {motor_id} temperature:{}", driver.act(motor_id, Command::ReadTemperature).unwrap());
+    }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,7 @@ pub enum Command {
     ReadId,
     WriteTorqueSwitch(bool),
     ReadCurrentPosition,
-
+    ReadTemperature,
     WriteTargetPosition(u16),
 }
 
@@ -20,6 +20,9 @@ impl Command {
             }
             Command::ReadCurrentPosition => {
                 InstructionPacket::new(motor_id, Instruction::Read, &[0x38, 2])
+            }
+            Command::ReadTemperature => {
+                InstructionPacket::new(motor_id, Instruction::Read, &[0x3F, 1])
             }
             Command::WriteTargetPosition(target_position) => {
                 let low: u8 = (*target_position >> 8) as u8;
@@ -46,6 +49,10 @@ mod tests {
                 Command::WriteTargetPosition(1025),
                 InstructionPacket::new(motor_id, Instruction::Write, &[0x2A, 0x1, 0x4]),
             ),
+            (
+                Command::ReadTemperature,
+                InstructionPacket::new(motor_id, Instruction::Read, &[0x3F, 1]),
+            )
         ];
         for (command, instruction_packet) in cases {
             assert_eq!(command.to_instruction_packet(motor_id), instruction_packet);


### PR DESCRIPTION
Verified w/ SOArm100 attached
```bash
➜  feetech-servo-rs git:(bradley_0) ✗ cargo run --example get_info
   Compiling feetech-servo-rs v0.1.0 (/Users/bd/Development/recurse/feetech-servo-rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.62s
     Running `target/debug/examples/get_info`
Enter the port (default: /dev/ttyACM0):
/dev/tty.usbmodem58FD0167291
Enter the number of motors:
6
motor 1 temperature:24
motor 2 temperature:25
motor 3 temperature:25
motor 4 temperature:25
motor 5 temperature:25
motor 6 temperature:26
```