### PR TITLE
Add Acceleration Read and write

### DIFF
--- a/examples/accelerate_move.rs
+++ b/examples/accelerate_move.rs
@@ -1,0 +1,35 @@
+use std::io::{self};
+
+use feetech_servo_rs::{Command, Driver};
+
+fn main() {
+    println!("Enter the port (default: /dev/tty.usbmodem58FD0166701");
+    let mut port = String::new();
+    let _ = io::stdin().read_line(&mut port);
+    let port = match port.trim() {
+        "" => "/dev/tty.usbmodem58FD0166701",
+        other => other,
+    };
+    let mut driver = Driver::new(port);
+
+    let mo1_pos = driver.act(1, Command::ReadCurrentPosition).unwrap();
+    println!("Motor 1 is at {}", mo1_pos);
+
+    println!("Enter how fast do you want to go? ");
+    let mut new_accel = String::new();
+    let _ = io::stdin().read_line(&mut new_accel);
+    let new_accel: u8 = new_accel.trim().parse().expect("Please type a number!");
+
+    driver
+        .act(1, Command::WriteAcceleration(new_accel))
+        .unwrap();
+
+    println!("Enter where do you want to go?");
+    let mut new_pos = String::new();
+    let _ = io::stdin().read_line(&mut new_pos);
+    let new_pos: u16 = new_pos.trim().parse().expect("Please type a number!");
+
+    driver
+        .act(1, Command::WriteTargetPosition(new_pos))
+        .unwrap();
+}

--- a/examples/get_info.rs
+++ b/examples/get_info.rs
@@ -17,6 +17,13 @@ fn main() {
     let _ = io::stdin().read_line(&mut num_motors);
     let num_motors: u8 = num_motors.trim().parse().expect("Please type a number!");
     for motor_id in 1..=num_motors {
-        println!("motor {motor_id} temperature:{}", driver.act(motor_id, Command::ReadTemperature).unwrap());
+        println!(
+            "motor {motor_id} temperature:{}",
+            driver.act(motor_id, Command::ReadTemperature).unwrap()
+        );
+        println!(
+            "motor {motor_id} acceleration: {}",
+            driver.act(motor_id, Command::ReadAcceleration).unwrap()
+        )
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,6 +8,8 @@ pub enum Command {
     ReadCurrentPosition,
     ReadTemperature,
     WriteTargetPosition(u16),
+    ReadAcceleration,
+    WriteAcceleration(u8),
 }
 
 impl Command {
@@ -28,6 +30,12 @@ impl Command {
                 let low: u8 = (*target_position >> 8) as u8;
                 let high: u8 = (*target_position & 0x00FF) as u8;
                 InstructionPacket::new(motor_id, Instruction::Write, &[0x2A, high, low])
+            }
+            Command::ReadAcceleration => {
+                InstructionPacket::new(motor_id, Instruction::Read, &[0x29, 1])
+            }
+            Command::WriteAcceleration(acceleration) => {
+                InstructionPacket::new(motor_id, Instruction::Write, &[0x29, *acceleration])
             }
         }
     }
@@ -52,7 +60,7 @@ mod tests {
             (
                 Command::ReadTemperature,
                 InstructionPacket::new(motor_id, Instruction::Read, &[0x3F, 1]),
-            )
+            ),
         ];
         for (command, instruction_packet) in cases {
             assert_eq!(command.to_instruction_packet(motor_id), instruction_packet);


### PR DESCRIPTION
This PR:
- adds acceleration handlers (read and write) to the commands.
- adds an `accelerate_move.rs` example to demonstrate functionality.

### Open Discussion
We also adapted the `get_info.rs` example to print the acceleration. Since that almost always is zero in that example I'm unsure how sensible it is to have that. 
I kept it since it was a part of our pairing session but if we don't want that change, I can revert the commit cb478b18ce0d3a354805f64a4b7fec8445a16aff. 

Let me know